### PR TITLE
fix: add development branch configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,9 @@
 name: Build and Release
 on:
   push:
-    branches: [master]
+    branches:
+      - development
+      - master
   pull_request:
     branches: [master]
 
@@ -15,16 +17,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 10
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '22.x'
           cache: 'pnpm'
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 10
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
@@ -107,6 +109,7 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,6 +1,10 @@
 {
   "branches": [
-    "master"
+    "master",
+    {
+      "name": "development",
+      "prerelease": true
+    }
   ],
   "plugins": [
     "@semantic-release/commit-analyzer",
@@ -8,7 +12,8 @@
     [
       "@semantic-release/changelog",
       {
-        "changelogFile": "CHANGELOG.md"
+        "changelogFile": "CHANGELOG.md",
+        "changelogTitle": "# Changelog\n\nAll notable changes to this project will be documented in this file.\n\nThe format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),\nand this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)."
       }
     ],
     [
@@ -16,7 +21,9 @@
       {
         "assets": [
           "CHANGELOG.md",
-          "package.json"
+          "package.json",
+          "package-lock.json",
+          "pnpm-lock.yaml"
         ],
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }


### PR DESCRIPTION
This pull request updates the release configuration to better support prerelease workflows and changelog management. The most important changes are grouped below:

Release workflow improvements:
* Added the `development` branch as a prerelease branch in `.releaserc.json`, allowing for prerelease versions to be published from development instead of only master.

Changelog and asset management:
* Updated the changelog plugin configuration to include a custom changelog title and formatting, aligning with "Keep a Changelog" and "Semantic Versioning" standards.
* Expanded the list of assets managed by the git plugin to include `package-lock.json` and `pnpm-lock.yaml` in addition to `package.json` and `CHANGELOG.md`.